### PR TITLE
cargo install 対応 + Tauri ビルド CI (Linux/macOS)

### DIFF
--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -1,0 +1,43 @@
+name: Tauri
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: cargo build --release -p tvine

--- a/docs/notes/mvp/installation.md
+++ b/docs/notes/mvp/installation.md
@@ -1,0 +1,24 @@
+# インストール手順
+
+## 前提条件
+
+- Rust ツールチェイン（`rustup` 経由）
+- Node.js 22+
+- pnpm 10+
+
+## cargo install でインストール
+
+```bash
+cargo install --git https://github.com/minty1202/tvine
+```
+
+`dist/` が存在しない場合、`build.rs` が自動で `pnpm install` + `pnpm build` を実行する。
+
+## 開発環境のセットアップ
+
+```bash
+git clone https://github.com/minty1202/tvine.git
+cd tvine
+pnpm install
+cargo tauri dev
+```

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,23 @@
+use std::path::Path;
+use std::process::Command;
+
 fn main() {
+    let dist_dir = Path::new("../dist");
+    if !dist_dir.exists() {
+        let status = Command::new("pnpm")
+            .args(["install", "--frozen-lockfile"])
+            .current_dir("..")
+            .status()
+            .expect("pnpm install failed. Is pnpm installed?");
+        assert!(status.success(), "pnpm install failed");
+
+        let status = Command::new("pnpm")
+            .args(["run", "build"])
+            .current_dir("..")
+            .status()
+            .expect("pnpm build failed. Is Node.js installed?");
+        assert!(status.success(), "pnpm build failed");
+    }
+
     tauri_build::build()
 }


### PR DESCRIPTION
## Summary
- `build.rs` で `dist/` が存在しない場合に `pnpm install` + `pnpm build` を自動実行し、`cargo install --git` での配布に対応
- Tauri ビルド CI を追加（Linux + macOS matrix）
- インストール手順メモを `docs/notes/mvp/installation.md` に追加

## Test plan
- [x] ローカルで `dist/` を削除して `cargo build -p tvine` が通ることを確認済み
- [ ] CI で Linux / macOS の Tauri ビルドが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)