### PR TITLE
refactor: テストの一時ディレクトリを tempfile クレートに移行

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "exec",
  "kernel",
  "shared",
+ "tempfile",
 ]
 
 [[package]]
@@ -119,6 +120,7 @@ dependencies = [
  "kernel",
  "registry",
  "shared",
+ "tempfile",
  "uuid",
 ]
 
@@ -788,7 +790,7 @@ dependencies = [
  "kernel",
  "serde",
  "serde_json",
- "shared",
+ "tempfile",
 ]
 
 [[package]]
@@ -3579,7 +3581,6 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "dirs",
- "git2",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ dirs = "6.0.0"
 git2 = "0.20"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
+tempfile = "3"

--- a/crates/adapter/Cargo.toml
+++ b/crates/adapter/Cargo.toml
@@ -12,3 +12,6 @@ shared.workspace = true
 
 async-trait.workspace = true
 derive-new.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/adapter/src/manage/initializer/mod.rs
+++ b/crates/adapter/src/manage/initializer/mod.rs
@@ -23,58 +23,41 @@ impl Initializer for InitializerImpl {
 mod tests {
     use super::*;
 
-    fn setup(name: &str) -> std::path::PathBuf {
-        let test_dir = shared::utility::test_dir().unwrap().join(name);
-        let _ = std::fs::remove_dir_all(&test_dir);
-        std::fs::create_dir_all(&test_dir).unwrap();
-        test_dir
-    }
-
-    fn cleanup(test_dir: &std::path::Path) {
-        let _ = std::fs::remove_dir_all(test_dir);
-    }
-
     // ensure_root_dir で .tvine ディレクトリが作成される
     #[test]
     fn ensure_root_dir_creates_tvine_directory() {
-        let test_dir = setup("ensure");
-        let ctx = AppContext::new(test_dir.clone());
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = AppContext::new(tmp.path().to_path_buf());
         let initializer = InitializerImpl::new(ctx);
 
         let result = initializer.ensure_root_dir();
         assert!(result.is_ok());
-        assert!(test_dir.join(".tvine").exists());
-
-        cleanup(&test_dir);
+        assert!(tmp.path().join(".tvine").exists());
     }
 
     // remove_root_dir で .tvine ディレクトリが削除される
     #[test]
     fn remove_root_dir_deletes_tvine_directory() {
-        let test_dir = setup("remove");
-        let ctx = AppContext::new(test_dir.clone());
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = AppContext::new(tmp.path().to_path_buf());
         let initializer = InitializerImpl::new(ctx);
 
         initializer.ensure_root_dir().unwrap();
-        assert!(test_dir.join(".tvine").exists());
+        assert!(tmp.path().join(".tvine").exists());
 
         let result = initializer.remove_root_dir();
         assert!(result.is_ok());
-        assert!(!test_dir.join(".tvine").exists());
-
-        cleanup(&test_dir);
+        assert!(!tmp.path().join(".tvine").exists());
     }
 
     // remove_root_dir はディレクトリが存在しなくてもエラーにならない
     #[test]
     fn remove_root_dir_succeeds_when_not_exists() {
-        let test_dir = setup("remove_not_exists");
-        let ctx = AppContext::new(test_dir.clone());
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = AppContext::new(tmp.path().to_path_buf());
         let initializer = InitializerImpl::new(ctx);
 
         let result = initializer.remove_root_dir();
         assert!(result.is_ok());
-
-        cleanup(&test_dir);
     }
 }

--- a/crates/adapter/src/repository/session.rs
+++ b/crates/adapter/src/repository/session.rs
@@ -37,19 +37,10 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    fn setup() -> PathBuf {
-        shared::utility::test_dir().unwrap()
-    }
-
-    fn cleanup(test_dir: &std::path::Path) {
-        let _ = std::fs::remove_dir_all(test_dir);
-    }
-
     #[test]
     fn create_delegates_to_save_session() {
-        let test_dir = setup().join("session_repo");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
+        let tmp = tempfile::tempdir().unwrap();
+        let app = Arc::new(AppContext::new(tmp.path().to_path_buf()));
         let repo_root = PathBuf::from("/Users/aki/dev/test");
         let id = ProjectId::from(repo_root.as_path());
         let ctx = ProjectContext::new(app, id, repo_root);
@@ -71,7 +62,5 @@ mod tests {
             .join("adapter-test-uuid")
             .join("session.json")
             .exists());
-
-        cleanup(&test_dir);
     }
 }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -10,3 +10,6 @@ registry.workspace = true
 shared.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/api/src/operator/mod.rs
+++ b/crates/api/src/operator/mod.rs
@@ -54,14 +54,6 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    fn setup() -> std::path::PathBuf {
-        shared::utility::test_dir().unwrap()
-    }
-
-    fn cleanup(test_dir: &std::path::Path) {
-        let _ = std::fs::remove_dir_all(test_dir);
-    }
-
     // テスト用の BootstrapRegistry 実装
     // MockBootstrapRegistry は &dyn Prerequisite の返却が難しいため、手動で用意する
     struct TestBootstrapRegistry {
@@ -179,27 +171,22 @@ mod tests {
     // initialize_project がプロジェクトディレクトリを作成する
     #[test]
     fn initialize_project_creates_project_directory() {
-        let test_dir = setup().join("init_project");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
-        let repo_root = std::path::PathBuf::from("/Users/aki/dev/test");
+        let tmp = tempfile::tempdir().unwrap();
+        let app = Arc::new(AppContext::new(tmp.path().to_path_buf()));
+        let repo_root = PathBuf::from("/Users/aki/dev/test");
         let id = ProjectId::from(repo_root.as_path());
         let ctx = ProjectContext::new(app, id, repo_root);
 
         let result = initialize_project(&ctx, "main");
         assert!(result.is_ok());
         assert!(ctx.storage_dir().join("project.json").exists());
-
-        cleanup(&test_dir);
     }
 
     // initialize_project が IO エラー時に AppError::IoError を返す
     #[test]
     fn initialize_project_returns_io_error_on_failure() {
-        let app = Arc::new(AppContext::new(std::path::PathBuf::from(
-            "/nonexistent/path",
-        )));
-        let repo_root = std::path::PathBuf::from("/Users/aki/dev/test");
+        let app = Arc::new(AppContext::new(PathBuf::from("/nonexistent/path")));
+        let repo_root = PathBuf::from("/Users/aki/dev/test");
         let id = ProjectId::from(repo_root.as_path());
         let ctx = ProjectContext::new(app, id, repo_root);
 
@@ -246,9 +233,8 @@ mod tests {
     // 有効なセッション（worktree が存在する）は削除されない
     #[test]
     fn reconcile_sessions_keeps_valid_sessions() {
-        let test_dir = setup().join("reconcile_valid");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let valid = make_session("valid-id", test_dir.clone());
+        let tmp = tempfile::tempdir().unwrap();
+        let valid = make_session("valid-id", tmp.path().to_path_buf());
 
         let mut session_mock = MockSessionRepository::new();
         session_mock
@@ -265,7 +251,5 @@ mod tests {
 
         let result = reconcile_sessions(&registry);
         assert!(result.is_ok());
-
-        cleanup(&test_dir);
     }
 }

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -9,4 +9,4 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-shared.workspace = true
+tempfile.workspace = true

--- a/crates/data/src/manage/project.rs
+++ b/crates/data/src/manage/project.rs
@@ -36,22 +36,17 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    fn setup() -> PathBuf {
-        shared::utility::test_dir().unwrap()
-    }
-
-    fn cleanup(test_dir: &std::path::Path) {
-        let _ = std::fs::remove_dir_all(test_dir);
+    fn make_ctx(base: &std::path::Path) -> ProjectContext {
+        let app = Arc::new(AppContext::new(base.to_path_buf()));
+        let repo_root = PathBuf::from("/Users/aki/dev/test");
+        let id = ProjectId::from(repo_root.as_path());
+        ProjectContext::new(app, id, repo_root)
     }
 
     #[test]
     fn ensure_project_dir_creates_structure() {
-        let test_dir = setup().join("creates_structure");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
-        let repo_root = PathBuf::from("/Users/aki/dev/test");
-        let id = ProjectId::from(repo_root.as_path());
-        let ctx = ProjectContext::new(app, id, repo_root);
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = make_ctx(tmp.path());
 
         let result = ensure_project_dir(&ctx, "main");
         assert!(result.is_ok());
@@ -66,23 +61,15 @@ mod tests {
         .unwrap();
         assert_eq!(config["root"], "/Users/aki/dev/test");
         assert_eq!(config["default_branch"], "main");
-
-        cleanup(&test_dir);
     }
 
     #[test]
     fn ensure_project_dir_is_idempotent() {
-        let test_dir = setup().join("idempotent");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
-        let repo_root = PathBuf::from("/Users/aki/dev/test");
-        let id = ProjectId::from(repo_root.as_path());
-        let ctx = ProjectContext::new(app, id, repo_root);
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = make_ctx(tmp.path());
 
         ensure_project_dir(&ctx, "main").unwrap();
         let result = ensure_project_dir(&ctx, "main");
         assert!(result.is_ok());
-
-        cleanup(&test_dir);
     }
 }

--- a/crates/data/src/manage/session.rs
+++ b/crates/data/src/manage/session.rs
@@ -56,22 +56,27 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    fn setup() -> PathBuf {
-        shared::utility::test_dir().unwrap()
+    fn make_ctx(base: &std::path::Path) -> ProjectContext {
+        let app = Arc::new(AppContext::new(base.to_path_buf()));
+        let repo_root = PathBuf::from("/Users/aki/dev/test");
+        let id = ProjectId::from(repo_root.as_path());
+        ProjectContext::new(app, id, repo_root)
     }
 
-    fn cleanup(test_dir: &std::path::Path) {
-        let _ = std::fs::remove_dir_all(test_dir);
+    fn make_session(id: &str, branch: &str) -> Session {
+        Session {
+            id: SessionId::new(id.to_string()),
+            branch_name: branch.to_string(),
+            base_branch: "main".to_string(),
+            worktree_path: PathBuf::from(format!("/Users/aki/dev/test-{}", branch)),
+            created_at: "2026-03-28T12:00:00Z".to_string(),
+        }
     }
 
     #[test]
     fn save_session_creates_session_json() {
-        let test_dir = setup().join("save_session");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
-        let repo_root = PathBuf::from("/Users/aki/dev/test");
-        let id = ProjectId::from(repo_root.as_path());
-        let ctx = ProjectContext::new(app, id, repo_root);
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = make_ctx(tmp.path());
 
         let session = Session {
             id: SessionId::new("test-uuid-1234".to_string()),
@@ -94,61 +99,33 @@ mod tests {
         assert_eq!(saved["id"], "test-uuid-1234");
         assert_eq!(saved["branch_name"], "feature/login");
         assert_eq!(saved["base_branch"], "main");
-
-        cleanup(&test_dir);
-    }
-
-    fn make_session(id: &str, branch: &str) -> Session {
-        Session {
-            id: SessionId::new(id.to_string()),
-            branch_name: branch.to_string(),
-            base_branch: "main".to_string(),
-            worktree_path: PathBuf::from(format!("/Users/aki/dev/test-{}", branch)),
-            created_at: "2026-03-28T12:00:00Z".to_string(),
-        }
     }
 
     #[test]
     fn list_sessions_returns_saved_sessions() {
-        let test_dir = setup().join("list_sessions");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
-        let repo_root = PathBuf::from("/Users/aki/dev/test");
-        let id = ProjectId::from(repo_root.as_path());
-        let ctx = ProjectContext::new(app, id, repo_root);
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = make_ctx(tmp.path());
 
         save_session(&ctx, &make_session("uuid-1", "feature/a")).unwrap();
         save_session(&ctx, &make_session("uuid-2", "feature/b")).unwrap();
 
         let sessions = list_sessions(&ctx).unwrap();
         assert_eq!(sessions.len(), 2);
-
-        cleanup(&test_dir);
     }
 
     #[test]
     fn list_sessions_returns_empty_when_no_sessions_dir() {
-        let test_dir = setup().join("list_empty");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
-        let repo_root = PathBuf::from("/Users/aki/dev/test");
-        let id = ProjectId::from(repo_root.as_path());
-        let ctx = ProjectContext::new(app, id, repo_root);
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = make_ctx(tmp.path());
 
         let sessions = list_sessions(&ctx).unwrap();
         assert!(sessions.is_empty());
-
-        cleanup(&test_dir);
     }
 
     #[test]
     fn delete_session_removes_session_dir() {
-        let test_dir = setup().join("delete_session");
-        std::fs::create_dir_all(&test_dir).unwrap();
-        let app = Arc::new(AppContext::new(test_dir.clone()));
-        let repo_root = PathBuf::from("/Users/aki/dev/test");
-        let id = ProjectId::from(repo_root.as_path());
-        let ctx = ProjectContext::new(app, id, repo_root);
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = make_ctx(tmp.path());
 
         save_session(&ctx, &make_session("uuid-del", "feature/x")).unwrap();
         assert!(ctx
@@ -158,7 +135,5 @@ mod tests {
 
         delete_session(&ctx, "uuid-del").unwrap();
         assert!(!ctx.storage_dir().join("sessions/uuid-del").exists());
-
-        cleanup(&test_dir);
     }
 }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -7,4 +7,3 @@ edition.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 dirs.workspace = true
-git2.workspace = true

--- a/crates/shared/src/utility.rs
+++ b/crates/shared/src/utility.rs
@@ -5,14 +5,3 @@ pub fn home_dir() -> io::Result<PathBuf> {
     dirs::home_dir()
         .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "HOME directory not found"))
 }
-
-pub fn test_dir() -> io::Result<PathBuf> {
-    let repo = git2::Repository::discover(".")
-        .map_err(|e| io::Error::new(io::ErrorKind::NotFound, e.to_string()))?;
-    let workspace_root = repo
-        .workdir()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "workspace root not found"))?;
-    let dir = workspace_root.join("tmp");
-    std::fs::create_dir_all(&dir)?;
-    Ok(dir)
-}


### PR DESCRIPTION
## Summary

- `shared::utility::test_dir()` + 手動 `cleanup()` を `tempfile::tempdir()` に置き換え
- `TempDir` の drop で自動削除されるため、パニック時のゴミ残りと並列実行の競合が解消
- `shared` クレートから不要になった `test_dir()` 関数と `git2` 依存を削除

## Test plan

- [x] `make ci` が通ること
- [x] `cargo test --workspace --exclude tvine` で全 31 テストが通ること