### PR TITLE
feat: README・インストールスクリプト・リリースワークフローを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - platform: macos-latest
+            args: --target aarch64-apple-darwin
+          - platform: macos-latest
+            args: --target x86_64-apple-darwin
+          # TODO: Linux 対応時に有効化
+          # - platform: ubuntu-latest
+          #   args: ''
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: pnpm install --frozen-lockfile
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: Apple Developer Program に加入したら署名を有効化
+          # APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          # APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          # APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          # APPLE_API_KEY_PATH: ${{ secrets.APPLE_API_KEY_PATH }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: 'tvine ${{ github.ref_name }}'
+          releaseBody: 'See the assets to download this version.'
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-# Tauri + React + Typescript
+# tvine
 
-This template should help get you started developing with Tauri, React and Typescript in Vite.
+Worktree × AI 並列開発ツール。Git worktree を活用して複数の AI エージェントを同時に走らせ、開発を並列化するデスクトップアプリ。
 
-## Recommended IDE Setup
+> **Status:** 開発中（MVP）
 
-- [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+## インストール
+
+### macOS
+
+```sh
+curl -sSL https://raw.githubusercontent.com/minty1202/tvine/main/install.sh | bash
+```
+
+`.app` の配置と `tvine` コマンドのセットアップを自動で行います。
+
+> 署名なしのため、初回は右クリック →「開く」で起動する必要があります。
+
+<!-- TODO: Linux 対応時に追記 -->

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO="minty1202/tvine"
+APP_NAME="tvine"
+INSTALL_DIR="/Applications"
+BIN_DIR="/usr/local/bin"
+
+info() { printf "\033[34m%s\033[0m\n" "$1"; }
+error() { printf "\033[31mError: %s\033[0m\n" "$1" >&2; exit 1; }
+
+# --- OS・アーキテクチャ判定 ---
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Darwin) ;;
+  *) error "現在 macOS のみ対応しています" ;;
+esac
+
+case "$ARCH" in
+  arm64)  TARGET="aarch64" ;;
+  x86_64) TARGET="x86_64" ;;
+  *) error "未対応のアーキテクチャです: $ARCH" ;;
+esac
+
+info "検出: macOS $ARCH ($TARGET)"
+
+# --- 最新リリースのダウンロード URL を取得 ---
+
+info "最新リリースを確認中..."
+
+DOWNLOAD_URL=$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep -o "\"browser_download_url\": *\"[^\"]*${TARGET}[^\"]*\.dmg\"" \
+  | head -1 \
+  | cut -d'"' -f4) || true
+
+if [ -z "$DOWNLOAD_URL" ]; then
+  error "ダウンロード URL が見つかりません。リリースが公開されているか確認してください: https://github.com/${REPO}/releases"
+fi
+
+info "ダウンロード: $DOWNLOAD_URL"
+
+# --- ダウンロード ---
+
+TMP_DIR=$(mktemp -d)
+DMG_PATH="${TMP_DIR}/${APP_NAME}.dmg"
+
+cleanup() {
+  if [ -d "/Volumes/${APP_NAME}" ]; then
+    hdiutil detach "/Volumes/${APP_NAME}" -quiet 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+curl -sSfL -o "$DMG_PATH" "$DOWNLOAD_URL"
+
+# --- インストール ---
+
+info "${APP_NAME}.app をインストール中..."
+
+hdiutil attach "$DMG_PATH" -quiet -nobrowse -mountpoint "/Volumes/${APP_NAME}"
+
+if [ -d "${INSTALL_DIR}/${APP_NAME}.app" ]; then
+  info "既存の ${APP_NAME}.app を上書きします"
+  rm -rf "${INSTALL_DIR}/${APP_NAME}.app"
+fi
+
+cp -R "/Volumes/${APP_NAME}/${APP_NAME}.app" "$INSTALL_DIR/"
+
+# --- シンボリックリンク ---
+
+info "${BIN_DIR}/${APP_NAME} にリンクを作成中..."
+
+if [ ! -d "$BIN_DIR" ]; then
+  sudo mkdir -p "$BIN_DIR"
+fi
+
+sudo ln -sf "${INSTALL_DIR}/${APP_NAME}.app/Contents/MacOS/${APP_NAME}" "${BIN_DIR}/${APP_NAME}"
+
+# --- 完了 ---
+
+info "インストール完了!"
+info "  アプリ: ${INSTALL_DIR}/${APP_NAME}.app"
+info "  コマンド: ${APP_NAME}"

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,14 +1,15 @@
 import { Flex } from '@mantine/core';
 import { Panel } from '@/components/panel/Panel';
-import {
-  DiffPanel,
-  DiffPanelToggle,
-} from '@/features/diff/components/DiffPanel';
+// TODO: diff・shell パネルは未実装
+// import {
+//   DiffPanel,
+//   DiffPanelToggle,
+// } from '@/features/diff/components/DiffPanel';
 import { SessionSidebar } from '@/features/sessions/components/SessionSidebar';
-import {
-  ShellPanel,
-  ShellPanelToggle,
-} from '@/features/shell/components/ShellPanel';
+// import {
+//   ShellPanel,
+//   ShellPanelToggle,
+// } from '@/features/shell/components/ShellPanel';
 import { MainTerminalPanel } from '@/features/terminal/components/MainTerminalPanel';
 
 export function Layout() {
@@ -19,21 +20,13 @@ export function Layout() {
       <Panel.Divider />
 
       <MainTerminalPanel
-        panelToggles={
-          <>
-            <DiffPanelToggle />
-            <ShellPanelToggle />
-          </>
-        }
+      // panelToggles={
+      //   <>
+      //     <DiffPanelToggle />
+      //     <ShellPanelToggle />
+      //   </>
+      // }
       />
-
-      <Panel.Divider />
-
-      <DiffPanel />
-
-      <Panel.Divider />
-
-      <ShellPanel />
     </Flex>
   );
 }


### PR DESCRIPTION
## Summary

- README をプロジェクト説明 + `curl | bash` インストール手順に更新
- `install.sh` で GitHub Releases から `.dmg` を取得し `/Applications` 配置 + symlink 作成
- GitHub Actions で `v*` タグ push 時に macOS 向け `.dmg` をビルドして Draft Release に添付
- 未実装の DiffPanel・ShellPanel を Layout からコメントアウト

## Test plan

- [ ] `pnpm run lint` パス
- [ ] `pnpm test` パス
- [ ] `pnpm run build` パス