### PR TITLE
fix: セッション作成モーダルの自動大文字変換を無効化

### DIFF
--- a/src/features/sessions/components/CreateSessionModal.tsx
+++ b/src/features/sessions/components/CreateSessionModal.tsx
@@ -66,11 +66,15 @@ export function CreateSessionModal({ mutation }: CreateSessionModalProps) {
             )}
             <TextInput
               label="ベースブランチ"
+              autoCapitalize="off"
+              autoCorrect="off"
               {...form.getInputProps('baseBranch')}
             />
             <TextInput
               label="ブランチ名"
               placeholder="feature/xxx"
+              autoCapitalize="off"
+              autoCorrect="off"
               {...form.getInputProps('branchName')}
             />
             <Button fullWidth type="submit" loading={mutation.isPending}>


### PR DESCRIPTION
## Summary

- セッション作成モーダルの「ベースブランチ」「ブランチ名」入力欄に `autoCapitalize="off"` と `autoCorrect="off"` を追加
- macOS の自動大文字変換・自動修正がブランチ名入力時に干渉する問題を解消

Closes #43