### PR TITLE
fix: git リポジトリ外で実行時に panic しないようにする

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,10 +42,13 @@ fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    if let Err(e) = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .setup(setup)
         .invoke_handler(routes::handler())
         .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+    {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary

- `tauri::Builder::run()` の `.expect()` を `if let Err` に変更し、エラー時は stderr にメッセージを出力して `exit(1)` で終了するようにした

## Test plan

- [ ] git リポジトリ外（例: `/tmp`）で `tvine` を実行し、panic せずにエラーメッセージが表示されて終了することを確認
- [ ] git リポジトリ内で `tvine` を実行し、正常に起動することを確認

Closes #36