### PR TITLE
fix: tvine コマンドがターミナルを占有しないようにする

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,11 @@ if [ ! -d "$BIN_DIR" ]; then
   sudo mkdir -p "$BIN_DIR"
 fi
 
-sudo ln -sf "${INSTALL_DIR}/${APP_NAME}.app/Contents/MacOS/${APP_NAME}" "${BIN_DIR}/${APP_NAME}"
+cat <<SCRIPT | sudo tee "${BIN_DIR}/${APP_NAME}" > /dev/null
+#!/bin/bash
+open "${INSTALL_DIR}/${APP_NAME}.app" "\$@"
+SCRIPT
+sudo chmod +x "${BIN_DIR}/${APP_NAME}"
 
 # --- 完了 ---
 


### PR DESCRIPTION
## Summary

- `install.sh` でシンボリックリンクの代わりに `open` コマンドを使うラッパースクリプトを配置
- `tvine` コマンド実行時にアプリがバックグラウンドで起動し、ターミナルがすぐに返るようになる

## Test plan

- [ ] `install.sh` を実行後、`tvine` コマンドでアプリが起動しターミナルがブロックされないことを確認
- [ ] `cat /usr/local/bin/tvine` でラッパースクリプトの中身が正しいことを確認

Closes #39