### PR TITLE
fix: v0.1.1 で起動時にクラッシュする問題を修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,8 @@ fi
 
 cat <<SCRIPT | sudo tee "${BIN_DIR}/${APP_NAME}" > /dev/null
 #!/bin/bash
-open "${INSTALL_DIR}/${APP_NAME}.app" "\$@"
+nohup "${INSTALL_DIR}/${APP_NAME}.app/Contents/MacOS/${APP_NAME}" "\$@" >/dev/null 2>&1 &
+disown
 SCRIPT
 sudo chmod +x "${BIN_DIR}/${APP_NAME}"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,14 @@ use shared::utility;
 use tauri::Manager;
 
 fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    if let Err(e) = setup_inner(app) {
+        show_error_dialog(&e.to_string());
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn setup_inner(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let home_dir = utility::home_dir()?;
 
     let app_ctx = AppContext::new(home_dir.clone());
@@ -38,6 +46,18 @@ fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     app.manage(app_handle);
 
     Ok(())
+}
+
+fn show_error_dialog(message: &str) {
+    let _ = std::process::Command::new("osascript")
+        .args([
+            "-e",
+            &format!(
+                "display dialog \"{}\" with title \"tvine\" buttons {{\"OK\"}} default button \"OK\" with icon stop",
+                message.replace('\"', "\\\"").replace('\n', " ")
+            ),
+        ])
+        .output();
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]


### PR DESCRIPTION
## Summary

- `install.sh` のラッパースクリプトを `open` から `nohup` + `disown` 方式に変更。CWD を保持しつつターミナルを解放する
- setup hook のエラーを `osascript` ダイアログで表示してから `exit(1)` するようにし、Tauri 内部の panic を回避

## 原因

PR #48 で `open` コマンドに変更したことで、起動時の CWD が `/` になり git リポジトリが見つからずクラッシュしていた。また Tauri は setup hook の `Err` を内部で panic に変換するため、`if let Err` では捕捉できなかった。

## Test plan

- [x] git リポジトリ内で `tvine` を実行し、正常に起動することを確認
- [x] git リポジトリ外で `tvine` を実行し、ダイアログでエラーが表示されて終了することを確認
- [x] `tvine` 実行後、ターミナルがブロックされないことを確認

Closes #58